### PR TITLE
add lint commit hook

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,3 @@
+[flake8]
+exclude: __pycache__,*.pyc,venv
+ignore: E121,E128,E201,E202,E221,E222,E241,E302,E4,E5,E265,E731

--- a/.jshintrc
+++ b/.jshintrc
@@ -1,0 +1,11 @@
+{
+  "curly": true,
+  "eqeqeq": true,
+  "immed": true,
+  "latedef": false,
+  "trailing": false,
+  "browser": true,
+  "devel": true,
+  "esnext": true,
+  "laxbreak": true
+}

--- a/.pre-commit
+++ b/.pre-commit
@@ -1,0 +1,33 @@
+#!/usr/bin/env sh
+
+exitstatus=0
+committed=`git diff-index --cached --name-only HEAD`
+
+# jshint only if js files have been edited
+if echo "$committed" | grep '.js$' >/dev/null 2>&1; then
+     node_modules/jshint/bin/jshint --reporter node_modules/jshint-stylish mobile-app >/dev/null 2>&1
+
+    if [ "$?" -ne "0" ]; then
+         node_modules/jshint/bin/jshint --reporter node_modules/jshint-stylish mobile-app
+
+        echo "Found issues in javascript."
+        exitstatus=1
+    fi
+fi
+
+if [ "$exitstatus" -eq 0 ]; then
+    venv/bin/flake8 . >/dev/null 2>&1
+
+    if [ "$?" -ne "0" ]; then
+        venv/bin/flake8 .
+
+        echo "Found issues in python."
+        exitstatus=1
+    fi
+fi
+
+if [ "$exitstatus" -ne 0 ]; then
+    echo "Commit aborted."
+fi
+
+exit $exitstatus

--- a/requirements.txt
+++ b/requirements.txt
@@ -71,4 +71,4 @@ simplejson==3.8.0
 fuzzywuzzy==0.6.1
 python-Levenshtein
 google-api-python-client==1.4.1
-flickr_api==0.5
+flickr_api==0.5flake8==2.4.1


### PR DESCRIPTION
everyone has to run 

``` bash
cp .pre-commit .git/hooks/pre-commit
chmod +x .git/hooks/pre-commit
```

to install the pre commit hook but before that, you should make sure

``` bash
node_modules/jshint/bin/jshint --reporter node_modules/jshint-stylish mobile-app
```

and

``` bash
venv/bin/flake8 .
```

run and have no errors.

you can change the linting rules in .flake8 and .jshintrc
